### PR TITLE
Bump plugin version to 1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mach10",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "description": "Structured agentic development methodology - from issue analysis to merge",
   "author": {
     "name": "Kevin Ryan"


### PR DESCRIPTION
## Summary
- Bump plugin version in plugin.json from 0.4.2 to 1.0.0 for open-source release

## Test plan
- [x] Verify plugin.json version reads "1.0.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)