### PR TITLE
Add critical evaluation category to issue-assessment (Fixes #124)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mach10",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "Structured agentic development methodology - from issue analysis to merge",
   "author": {
     "name": "Kevin Ryan"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ When no issue exists yet, start here. Claude helps you draft a structured GitHub
 
 **Command:** `/mach10:issue-assessment <number>`
 
-Claude reads the issue, explores the relevant parts of the codebase, and presents its findings -- scope, risks, ambiguities, and a recommended next step.
+Claude reads the issue, explores the relevant parts of the codebase, and presents its findings -- scope, risks, ambiguities, critical evaluation, and a recommended next step.
 
 **Your role:** Read the assessment critically. Push back if the scope is wrong, if risks are missed, or if important ambiguities aren't surfaced. The assessment is posted as a GitHub comment, so it becomes shared context for every future session on this issue.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ When no issue exists yet, start here. Claude helps you draft a structured GitHub
 
 Claude reads the issue, explores the relevant parts of the codebase, and presents its findings -- scope, risks, ambiguities, critical evaluation, and a recommended next step.
 
-**Your role:** Read the assessment critically. Push back if the scope is wrong, if risks are missed, or if important ambiguities aren't surfaced. The assessment is posted as a GitHub comment, so it becomes shared context for every future session on this issue.
+**Your role:** Read the assessment critically. Push back if the scope is wrong, if risks are missed, if important ambiguities aren't surfaced, or if the critical evaluation raises legitimate concerns about the issue's premise. The assessment is posted as a GitHub comment, so it becomes shared context for every future session on this issue.
 
 ### Phase 2: Plan the implementation
 

--- a/commands/issue-assessment.md
+++ b/commands/issue-assessment.md
@@ -41,7 +41,7 @@ Parse and understand:
 
 ## Step 3: Explore the Codebase
 
-Launch 3-4 exploration agents in parallel using the Task tool (subagent_type: "feature-dev:code-explorer"). Each agent should trace through the code comprehensively and target a different aspect:
+Launch 4 exploration agents in parallel using the Task tool (subagent_type: "feature-dev:code-explorer"). Each agent should trace through the code comprehensively and target a different aspect:
 
 - **Relevant code**: Find existing code related to the issue. Trace through their implementation comprehensively, identifying patterns, conventions, and the design decisions that shaped them.
 - **Architecture**: Map the relevant architecture layers, abstractions, and data flow, tracing through the code comprehensively to understand how components interact and where boundaries lie.
@@ -60,7 +60,7 @@ Based on your understanding of the issue and codebase, present your assessment t
 4. **Ambiguities**: Any underspecified aspects, contradictions, or open questions in the issue.
 5. **Scope**: Your assessment of the size and complexity of the work.
 6. **Risks**: Potential pitfalls, edge cases, or architectural concerns.
-7. **Critical evaluation**: Evaluate the issue's premise and proposed approach against codebase evidence and established engineering principles. This category challenges whether the issue is asking for the right thing -- distinct from Ambiguities (underspecified aspects of the issue) and Risks (pitfalls assuming the issue is valid). Challenge only when grounded in evidence or principle -- do not speculate. All claims must be backed by specific references: cite files or patterns for codebase-based challenges; cite source code or documentation for claims about how established projects or codebases approach problems.
+7. **Critical evaluation**: Evaluate the issue's premise and proposed approach against codebase evidence and established engineering principles. This category challenges whether the issue is asking for the right thing -- distinct from Ambiguities (underspecified aspects of the issue) and Risks (pitfalls assuming the issue is valid). Challenge only when grounded in evidence or principle -- do not speculate. All claims must be backed by specific references: cite files or patterns for codebase-based challenges; cite established engineering principles or widely-known patterns for principle-based challenges.
    - Whether the codebase suggests a different or better approach than what the issue proposes
    - Whether the proposed change creates redundancy, conflicts, or maintenance burden given existing code
    - Whether the issue addresses symptoms rather than the root cause

--- a/commands/issue-assessment.md
+++ b/commands/issue-assessment.md
@@ -41,7 +41,7 @@ Parse and understand:
 
 ## Step 3: Explore the Codebase
 
-Launch 2-3 exploration agents in parallel using the Task tool (subagent_type: "feature-dev:code-explorer"). Each agent should trace through the code comprehensively and target a different aspect:
+Launch 3-4 exploration agents in parallel using the Task tool (subagent_type: "feature-dev:code-explorer"). Each agent should trace through the code comprehensively and target a different aspect:
 
 - **Relevant code**: Find existing code related to the issue. Trace through their implementation comprehensively, identifying patterns, conventions, and the design decisions that shaped them.
 - **Architecture**: Map the relevant architecture layers, abstractions, and data flow, tracing through the code comprehensively to understand how components interact and where boundaries lie.

--- a/commands/issue-assessment.md
+++ b/commands/issue-assessment.md
@@ -46,6 +46,7 @@ Launch 2-3 exploration agents in parallel using the Task tool (subagent_type: "f
 - **Relevant code**: Find existing code related to the issue. Trace through their implementation comprehensively, identifying patterns, conventions, and the design decisions that shaped them.
 - **Architecture**: Map the relevant architecture layers, abstractions, and data flow, tracing through the code comprehensively to understand how components interact and where boundaries lie.
 - **Prior work**: Check for related branches, PRs, or commits that may already address part of the issue. Trace through any partial implementations to assess their completeness and approach.
+- **Counter-evidence**: Look for codebase evidence that challenges the issue's premise or proposed approach. Identify existing patterns, design decisions, or prior solutions that suggest a different approach, reveal the issue may be addressing symptoms rather than root causes, or indicate the problem is a special case of something more general.
 
 Each agent should return a list of 5-10 key files. After agents complete, read all identified files to build deep understanding.
 
@@ -59,6 +60,14 @@ Based on your understanding of the issue and codebase, present your assessment t
 4. **Ambiguities**: Any underspecified aspects, contradictions, or open questions in the issue.
 5. **Scope**: Your assessment of the size and complexity of the work.
 6. **Risks**: Potential pitfalls, edge cases, or architectural concerns.
+7. **Critical evaluation**: Evaluate the issue's premise and proposed approach against codebase evidence and established engineering principles. This category challenges whether the issue is asking for the right thing -- distinct from Ambiguities (underspecified aspects of the issue) and Risks (pitfalls assuming the issue is valid). Challenge only when grounded in evidence or principle -- do not speculate. All claims must be backed by specific references: cite files or patterns for codebase-based challenges; cite source code or documentation for claims about how established projects or codebases approach problems.
+   - Whether the codebase suggests a different or better approach than what the issue proposes
+   - Whether the proposed change creates redundancy, conflicts, or maintenance burden given existing code
+   - Whether the issue addresses symptoms rather than the root cause
+   - Whether a more elegant design achieves the same goal with less complexity
+   - Whether the problem generalizes beyond the reporter's specific case -- a special case of a broader problem worth solving generally
+
+   If codebase exploration did not surface evidence relevant to evaluating the premise, state that no counter-evidence was found rather than manufacturing concerns. Do not make scheduling or prioritization judgments.
 
 ## Step 4a: Track Interaction Findings
 


### PR DESCRIPTION
## Summary
- Add "Counter-evidence" exploration lens to Step 3, instructing the agent to gather codebase evidence that challenges the issue's premise or proposed approach
- Add "Critical evaluation" as the 7th assessment category in Step 4, with 5 evaluation sub-bullets, evidence citation requirements, an escape hatch for when no counter-evidence exists, and explicit exclusion of scheduling/prioritization judgments
- Distinct from existing Ambiguities (underspecified aspects) and Risks (pitfalls assuming issue validity) -- this category challenges whether the issue is asking for the right thing

## Test plan
- [ ] Run `/mach10:issue-assessment` on a test issue and verify the Critical evaluation category appears in the output
- [ ] Verify the assessment challenges the premise only when codebase evidence supports it (no manufactured concerns)
- [ ] Confirm the category is clearly distinct from Ambiguities and Risks in the output

Fixes #124

---
Generated with [Claude Code](https://claude.com/claude-code)