### PR TITLE
Allow commands to use the user's selected model

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mach10",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Structured agentic development methodology - from issue analysis to merge",
   "author": {
     "name": "Kevin Ryan"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ scripts/                      # Utility scripts (repo maintenance, data collecti
 ```
 
 Each command file is a self-contained workflow specification with:
-- **YAML frontmatter**: `description`, `argument-hint`, `allowed-tools`, `model`
+- **YAML frontmatter**: `description`, `argument-hint`, `allowed-tools`
 - **Markdown body**: Step-by-step instructions Claude Code follows when the command is invoked
 
 ## Command Structure
@@ -52,7 +52,7 @@ When composing content for GitHub comments or issue bodies:
 When adding or modifying commands, follow the existing pattern:
 - YAML frontmatter must include `description` and `argument-hint`
 - Set `allowed-tools` to the minimum set needed (principle of least privilege)
-- Set `model: opus` for commands requiring deep reasoning (reviews, planning, implementation)
+- Omit the `model` field from command frontmatter so commands inherit the user's session model. For commands requiring deep reasoning (reviews, planning, assessment), add a bold startup notice after `**User input:** $ARGUMENTS` recommending Opus: `**Note:** This command performs best with an Opus-class model. On Sonnet or Haiku, results may be shallower.`
 - End commands with a "next step" suggestion that includes `/clear` guidance for session boundaries (omit `/clear` when the next command needs session context, e.g., `/mach10:push` after implementation)
 - Use `gh` CLI for all GitHub operations (issues, PRs, comments, CI logs)
 - Commands that modify code delegate to `/feature-dev:feature-dev` via the Skill tool
@@ -71,6 +71,7 @@ When adding or modifying commands, follow the existing pattern:
 - **Step 0 bootstrap sync**: The Step 0 bootstrap instruction (sequential task creation, step-order constraint, pending status) is duplicated between `CLAUDE.md` (Task Tracking section, normative definition) and seven command files: `commands/pr-review.md`, `commands/pr-review-fix.md`, `commands/pr-pre-merge.md`, `commands/doc-review.md`, `commands/issue-plan.md`, `commands/pr-create.md`, and `commands/issue-plan-review.md` (each in their Step 0 block). The command-file instances vary only in step count. Any change to the bootstrap wording or sequencing logic must be applied to all eight locations.
 - **Guard-sentence sync**: The guard-sentence framing ("All lenses are required -- [justification], so their corresponding evidence-gathering lens(es) must always run:") is duplicated across three command files: `commands/issue-assessment.md` (Step 3), `commands/issue-plan-review.md` (Step 2b), and `commands/issue-plan.md` (Step 2b). Only the framing structure is synchronized; justifications are intentionally command-specific (each references the evaluation steps and categories particular to that command). Any change to the framing pattern must be applied to all three locations.
 - **No-background-agent sync**: The `run_in_background` prohibition instruction is duplicated across six command files at nine agent-spawn sites. The multi-agent wording is: "Do NOT use `run_in_background: true` when launching these agents. For parallel execution, launch multiple foreground Task calls in a single message instead." The single-agent wording (used at one site) is: "Do NOT use `run_in_background: true` when launching this agent." The nine sites are: `commands/issue-assessment.md` (Step 3), `commands/issue-plan.md` (Steps 2b and 4), `commands/issue-plan-review.md` (Step 2b), `commands/doc-review.md` (Steps 3, 4, and 7), `commands/test-audit.md` (Step 3), and `commands/pr-review.md` (Step 4). All sites use the multi-agent wording except `commands/pr-review.md` Step 4, which uses the single-agent variant because it spawns a single sequential agent rather than a parallel fan-out. Any change to the instruction wording must be applied to all nine sites. Note: `commands/pr-review.md` Step 2 (line 67) contains a separate Skill pass-through instruction that tells the downstream `pr-review-toolkit` Skill not to use background agents -- that is a different mechanism (Skill delegation vs. direct Task call) and is not part of this sync.
+- **Opus-recommendation notice sync**: The bold startup notice `**Note:** This command performs best with an Opus-class model. On Sonnet or Haiku, results may be shallower.` is duplicated across four command files: `commands/pr-review.md`, `commands/issue-plan.md`, `commands/issue-plan-review.md`, and `commands/issue-assessment.md`. Each notice appears after `**User input:** $ARGUMENTS` and before the first step heading. Any change to the notice wording must be applied to all four locations.
 
 ### User Interaction Patterns
 
@@ -130,7 +131,7 @@ Agent definitions live in the `agents/` directory as markdown files with YAML fr
 
 - YAML frontmatter must include `name`, `description`, `model`, and `color`
 - `description` should explain when the agent should be used, with `<example>` blocks showing trigger scenarios
-- Set `model: inherit` to use the caller's model, or specify a model explicitly (e.g., `model: opus`)
+- Default to `model: inherit` so agents use the caller's model. Only specify an explicit model in rare, proven-necessary cases where a specific model is required regardless of caller context
 - `color` provides visual distinction in CLI output (e.g., `magenta`, `cyan`)
 - The markdown body defines the agent's system prompt: its role, review process, output format, and tone
 - Agents are invoked via the Task tool with `subagent_type` -- they do not have `allowed-tools` or `argument-hint` fields

--- a/commands/doc-review.md
+++ b/commands/doc-review.md
@@ -199,7 +199,7 @@ gh pr comment <pr-number> --body "..."
 The comment should include:
 - Files reviewed and what was updated
 - Findings that were rejected (for the record)
-- Attribution: "Documentation reviewed by Claude Opus 4.6"
+- Attribution -- identify yourself by your actual model name (e.g., "Documentation reviewed by Claude Sonnet 4.6" if running on Sonnet)
 
 When referring to numbered items (findings, suggestions, stages) in the comment body, use plain words like "finding 3" or "suggestion 3" -- not `#<number>` notation, which GitHub auto-links to issues/PRs.
 

--- a/commands/doc-review.md
+++ b/commands/doc-review.md
@@ -2,7 +2,6 @@
 description: Review and update documentation based on PR changes
 argument-hint: <pr-number> [scope]
 allowed-tools: Bash, Read, Grep, Glob, Task, TaskCreate, TaskUpdate, Edit, Write, AskUserQuestion
-model: opus
 ---
 
 # Documentation Review

--- a/commands/issue-assessment.md
+++ b/commands/issue-assessment.md
@@ -10,6 +10,8 @@ You are performing an independent assessment of a GitHub issue. Your goal is to 
 
 **User input:** $ARGUMENTS
 
+**Note:** This command performs best with an Opus-class model. On Sonnet or Haiku, results may be shallower.
+
 ## Step 1: Parse Input
 
 The user's input contains:

--- a/commands/issue-assessment.md
+++ b/commands/issue-assessment.md
@@ -2,7 +2,6 @@
 description: Read a GitHub issue, perform an independent assessment, and present findings
 argument-hint: <issue-number>
 allowed-tools: Bash, Read, Grep, Glob, Task, AskUserQuestion
-model: opus
 ---
 
 # Issue Assessment

--- a/commands/issue-implement.md
+++ b/commands/issue-implement.md
@@ -2,7 +2,6 @@
 description: Implement a specific stage of an issue's implementation plan using feature-dev
 argument-hint: <issue-number> <stage(s)> [context]
 allowed-tools: Bash, Read, Grep, Glob, Task, Edit, Write, Skill, AskUserQuestion
-model: opus
 ---
 
 # Implement Stage

--- a/commands/issue-plan-review.md
+++ b/commands/issue-plan-review.md
@@ -2,7 +2,6 @@
 description: Read a GitHub issue and all comments, review the implementation plan, and present findings
 argument-hint: <issue-number>
 allowed-tools: Bash, Read, Grep, Glob, Task, TaskCreate, TaskUpdate, AskUserQuestion
-model: opus
 ---
 
 # Issue Plan Review

--- a/commands/issue-plan-review.md
+++ b/commands/issue-plan-review.md
@@ -10,6 +10,8 @@ You are reviewing the implementation plan for a GitHub issue. Your goal is to re
 
 **User input:** $ARGUMENTS
 
+**Note:** This command performs best with an Opus-class model. On Sonnet or Haiku, results may be shallower.
+
 ## Step 0: Parse input and create task list
 
 The user's input contains:

--- a/commands/issue-plan.md
+++ b/commands/issue-plan.md
@@ -10,6 +10,8 @@ You are creating a staged implementation plan for a GitHub issue. Your goal is t
 
 **User input:** $ARGUMENTS
 
+**Note:** This command performs best with an Opus-class model. On Sonnet or Haiku, results may be shallower.
+
 ## Guardrails
 
 This command is strictly for **planning**. Do NOT:

--- a/commands/issue-plan.md
+++ b/commands/issue-plan.md
@@ -2,7 +2,6 @@
 description: Read a GitHub issue, analyze the codebase, and create a staged implementation plan
 argument-hint: <issue-number>
 allowed-tools: Bash, Read, Grep, Glob, Task, TaskCreate, TaskUpdate, AskUserQuestion
-model: opus
 ---
 
 # Issue Plan

--- a/commands/pr-ci-fix.md
+++ b/commands/pr-ci-fix.md
@@ -2,7 +2,6 @@
 description: Diagnose and fix failing CI checks on a pull request
 argument-hint: <pr-number> [context]
 allowed-tools: Bash, Read, Grep, Glob, Task, Edit, Write, Skill
-model: opus
 ---
 
 # Fix CI Failures

--- a/commands/pr-review-fix.md
+++ b/commands/pr-review-fix.md
@@ -2,7 +2,6 @@
 description: Fix specific issues from a PR review using feature-dev
 argument-hint: <pr-number> [--review-comment <id>] [--assessment-comment <id>] [findings] [context]
 allowed-tools: Bash, Read, Grep, Glob, Task, TaskCreate, TaskUpdate, Edit, Write, Skill, AskUserQuestion
-model: opus
 ---
 
 # Fix Review Issues

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -2,7 +2,6 @@
 description: Run a comprehensive PR review, post results, then independently assess each finding
 argument-hint: <pr-number> [aspects] [context]
 allowed-tools: Bash, Read, Grep, Glob, Task, TaskCreate, TaskUpdate, Skill, AskUserQuestion
-model: opus
 ---
 
 # Review PR

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -148,7 +148,7 @@ Post the assessment immediately as a reply comment on the PR — do not ask the 
 - Reference the review comment it is assessing (link to the specific comment URL from Step 3)
 - List each finding with its classification and reasoning
 - End with the staged implementation plan
-- Include model attribution at the bottom
+- Include model attribution at the bottom -- identify yourself by your actual model name (e.g., "Assessed by Claude Sonnet 4.6" if running on Sonnet)
 
 ```
 gh pr comment <pr-number> --body "..."

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -10,6 +10,8 @@ You are running a comprehensive review of a pull request, posting the results, t
 
 **User input:** $ARGUMENTS
 
+**Note:** This command performs best with an Opus-class model. On Sonnet or Haiku, results may be shallower.
+
 ## Step 0: Parse input and create task list
 
 The user's input typically contains:
@@ -87,7 +89,7 @@ The comment must include:
 - `<!-- mach10-review -->` as the very first line of the comment body (this invisible HTML marker enables reliable identification in future sessions)
 - The complete review findings (Critical, Important, Suggestions, Strengths), including any findings from supplementary agents merged into the appropriate severity categories with inline source attribution (e.g., "per plugin-dev:skill-reviewer")
 - F/S identifiers on every finding -- Critical and Important findings use `F<n>` numbered sequentially across both sections, Suggestions use `S<n>` with a separate counter (e.g., `**F1:** ...`, `**F2:** ...`, `**S1:** ...`)
-- Model attribution at the bottom (e.g., "Reviewed by Claude Opus 4.6")
+- Model attribution at the bottom -- identify yourself by your actual model name (e.g., "Reviewed by Claude Sonnet 4.6" if running on Sonnet)
 - A note that this is an automated review
 
 Format the comment as a well-structured markdown document that can serve as input to a future `/mach10:pr-review-fix` session.

--- a/commands/test-audit.md
+++ b/commands/test-audit.md
@@ -2,7 +2,6 @@
 description: Fan out subagents to audit test quality across the repo
 argument-hint: [optional-scope]
 allowed-tools: Bash, Read, Grep, Glob, Task, AskUserQuestion
-model: opus
 ---
 
 # Audit Tests


### PR DESCRIPTION
## Summary
- Remove hard-coded `model: opus` from 9 command files so commands inherit the user's session model.
- Add a bold one-line Opus-recommendation notice to 4 deep-reasoning commands (`pr-review`, `issue-plan`, `issue-plan-review`, `issue-assessment`).
- Replace hardcoded `Claude Opus 4.6` attribution strings in `pr-review.md` and `doc-review.md` with dynamic self-identification instructions.
- Update CLAUDE.md authoring guidance (commands omit `model:`; agents default to `model: inherit`) and add a sync entry for the new notice.
- Bump plugin version to 1.30.0.

## Test plan
- [ ] Run `grep -r "model: opus" commands/` and confirm no matches.
- [ ] Run `grep -rn "Reviewed by Claude Opus 4.6\|Documentation reviewed by Claude Opus 4.6" commands/` and confirm no matches.
- [ ] Run `grep -rn "^\*\*Note:\*\* This command performs best with an Opus-class model" commands/` and confirm exactly 4 matches (`pr-review.md`, `issue-plan.md`, `issue-plan-review.md`, `issue-assessment.md`).
- [ ] Open each of the 9 modified command files and confirm the YAML frontmatter has 3 fields (`description`, `argument-hint`, `allowed-tools`) and is well-formed.
- [ ] Open `CLAUDE.md` and confirm: the frontmatter field list no longer includes `model`, the Writing Commands guidance no longer prescribes `model: opus`, the Writing Agents section positions explicit model as a rare exception, and an "Opus-recommendation notice sync" entry is present and lists the 4 notice-bearing command files.
- [ ] Run `jq -r .version .claude-plugin/plugin.json` and confirm output is `1.30.0`.

Fixes #139

---
Generated with [Claude Code](https://claude.com/claude-code)